### PR TITLE
Resource start order + inventory convars

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -39,10 +39,7 @@ setr voice_useNativeAudio true
 setr voice_useSendingRangeOnly true
 
 ## ox_inventory
-setr inventory:framework "esx"
 setr inventory:locale "en"
-setr inventory:slots 50
-setr inventory:weight 30000
 
 ## Default & Standalone resources
 ensure chat

--- a/server.cfg
+++ b/server.cfg
@@ -38,6 +38,12 @@ setr voice_enableRadioAnim 1
 setr voice_useNativeAudio true
 setr voice_useSendingRangeOnly true
 
+## ox_inventory
+setr inventory:framework "esx"
+setr inventory:locale "en"
+setr inventory:slots 50
+setr inventory:weight 30000
+
 ## Default & Standalone resources
 ensure chat
 ensure spawnmanager
@@ -48,6 +54,8 @@ ensure bob74_ipl
 
 ## ESX Legacy
 ensure es_extended
+ensure ox_lib
+ensure ox_inventory
 ensure [esx]
 
 ## ESX Addons


### PR DESCRIPTION
Personally I wouldn't rely on batching resource starts with the directory since you can't control the order.
Unless everything has proper dependencies set, they may trigger an event or call an export from a resource that hasn't loaded yet.