### PR TITLE
fix(recipe) replace_strings after loading screen removal

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -243,17 +243,11 @@ tasks:
     dest: ./resources/[standalone]
     src: ./tmp/files/oxmysql.zip
 
-
   ## Patching configs: esx-radio
   - action: replace_string
     file: ./resources/[esx_addons]/esx-radio/config.lua
     search: 'Key = "UP"'
     replace: 'Key = "F5"'
-
-  - action: replace_string
-    mode: all_vars
-    file:
-      - ./resources/loadingscreen/config.js
 
   ## Cleanup
   - action: remove_path


### PR DESCRIPTION
Loading screen was removed, later in recipe tried to replace strings of loadingscreen config, causing error