### PR TITLE
add FiveM's sets locale to server.cfg

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -4,7 +4,7 @@
 #   | _|\__ \>  <  | |__| _| (_ |/ _ \ (__ \ V /    #
 #   |___|___/_/\_\ |____|___\___/_/ \_\___| |_|     #
 #                                                   #
-#     Discord: http://discord.esx-framework.org/     #
+#     Discord: http://discord.esx-framework.org/    #
 #     Website: https://esx-framework.org/           #
 #     CFG Docs: https://aka.cfx.re/server-commands  #
 # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -30,6 +30,7 @@ sets sv_projectDesc "{{recipeDescription}}"
 set mysql_connection_string "{{dbConnectionString}}"
 load_server_icon esxLogo.png
 sv_maxclients {{maxClients}}
+sets locale "root-AQ" 
 
 # System Administrators
 # ---------------------


### PR DESCRIPTION
Customers have to add this line themselves and/or confuse the esx locale setting with the Language setting for the serverlist. Having that setting in the server.cfg present should help with some mixups in general.