### PR TITLE
feat: ship ox_inventory by default

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -70,6 +70,22 @@ tasks:
     dest: ./resources/[standalone]
     src: ./tmp/files/oxmysql.zip
 
+  # ox_lib (dependency of ox_inventory)
+  - action: download_file
+    path: ./tmp/files/ox_lib.zip
+    url: https://github.com/overextended/ox_lib/releases/latest/download/ox_lib.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/files/ox_lib.zip
+
+  # ox_inventory
+  - action: download_file
+    path: ./tmp/files/ox_inventory.zip
+    url: https://github.com/overextended/ox_inventory/releases/latest/download/ox_inventory.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/files/ox_inventory.zip
+
   ## Cleanup
   - action: remove_path
     path: ./tmp

--- a/server.cfg
+++ b/server.cfg
@@ -75,6 +75,8 @@ sv_filterRequestControl 2
 ensure chat
 ensure hardcap
 ensure oxmysql
+ensure ox_lib
+ensure ox_inventory
 
 # ESX Legacy Core
 # ----------


### PR DESCRIPTION
Adds ox_lib and ox_inventory to the ESX Legacy recipe (built release artifacts, unzipped to resources/[standalone] like oxmysql). server.cfg ensures them before [core].

es_extended needs no config change — it auto-detects ox. No inventory:accounts convar and no SQL task: ox handles both itself.

Source = overextended upstream (the esx-framework fork has no built release).

Not tested at runtime — validation = txAdmin install + boot.
